### PR TITLE
feat: more natural swipes

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CC = clang
-CFLAGS = -std=c99 -O3 -march=native -flto -fomit-frame-pointer -funroll-loops -g -Wall -Wextra
+CFLAGS = -std=c99 -O3 -march=native -flto -fomit-frame-pointer -funroll-loops -g -Wall -Wextra -Wno-pointer-integer-compare -Wno-incompatible-pointer-types-discards-qualifiers -Wno-absolute-value
 FRAMEWORKS = -framework CoreFoundation -framework IOKit -F/System/Library/PrivateFrameworks -framework MultitouchSupport -framework ApplicationServices -framework Cocoa
 LDLIBS = -ldl
 TARGET = swipe

--- a/src/aerospace.c
+++ b/src/aerospace.c
@@ -14,7 +14,6 @@
 
 #define DEFAULT_MAX_BUFFER_SIZE 2048
 
-static const char* ERROR_MEM_ALLOC = "Memory allocation failed";
 static const char* ERROR_SOCKET_CREATE = "Failed to create Unix domain socket";
 static const char* ERROR_SOCKET_CONNECT_FMT = "Failed to connect to socket at %s";
 static const char* ERROR_SOCKET_SEND = "Failed to send data through socket";
@@ -24,7 +23,6 @@ static const char* ERROR_SOCKET_NOT_CONN = "Socket is not connected";
 static const char* ERROR_JSON_CREATE = "Failed to create JSON object/array";
 static const char* ERROR_JSON_PRINT = "Failed to print JSON to string";
 static const char* ERROR_JSON_DECODE = "Failed to decode JSON response";
-static const char* ERROR_USER_INFO = "Unable to determine user information for default socket path";
 static const char* ERROR_RESPONSE_FORMAT = "Response does not contain valid %s field";
 
 struct aerospace {

--- a/src/config.h
+++ b/src/config.h
@@ -33,7 +33,7 @@ static Config default_config()
 	config.swipe_cooldown = 0.3f;
 	config.distance_pct = 0.12f; // ≥12 % travel triggers
 	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
-	config.settle_factor = 0.10f; // ≤10 % of flick speed -> flick ended
+	config.settle_factor = 0.15f; // ≤15 % of flick speed -> flick ended
 	config.swipe_left = "prev";
 	config.swipe_right = "next";
 	return config;

--- a/src/config.h
+++ b/src/config.h
@@ -15,9 +15,8 @@ typedef struct {
 	bool skip_empty;
 	int fingers;
 	float swipe_cooldown;
-	float swipe_threshold; // distance
-	float velocity_swipe_threshold; // velocity
-	int velocity_frames_threshold; // distance
+	float distance_pct; // distance
+	float velocity_pct; // velocity
 	const char* swipe_left;
 	const char* swipe_right;
 } Config;
@@ -31,9 +30,8 @@ static Config default_config()
 	config.skip_empty = true;
 	config.fingers = 3;
 	config.swipe_cooldown = 0.3f;
-	config.swipe_threshold = 0.15f;
-	config.velocity_swipe_threshold = 0.75f;
-	config.velocity_frames_threshold = 2;
+	config.distance_pct = 0.12f; // ≥12 % travel triggers
+	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
 	config.swipe_left = "prev";
 	config.swipe_right = "next";
 	return config;
@@ -123,17 +121,13 @@ static Config load_config()
 	if (cJSON_IsNumber(item))
 		config.swipe_cooldown = (float)item->valuedouble;
 
-	item = cJSON_GetObjectItem(root, "swipe_threshold");
+	item = cJSON_GetObjectItem(root, "distance_pct");
 	if (cJSON_IsNumber(item))
-		config.swipe_threshold = (float)item->valuedouble;
+		config.distance_pct = (float)item->valuedouble;
 
-	item = cJSON_GetObjectItem(root, "velocity_swipe_threshold");
+	item = cJSON_GetObjectItem(root, "velocity_pct");
 	if (cJSON_IsNumber(item))
-		config.velocity_swipe_threshold = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "velocity_frames_threshold");
-	if (cJSON_IsNumber(item))
-		config.velocity_frames_threshold = item->valueint;
+		config.velocity_pct = (float)item->valuedouble;
 
 	config.swipe_left = config.natural_swipe ? "next" : "prev";
 	config.swipe_right = config.natural_swipe ? "prev" : "next";

--- a/src/config.h
+++ b/src/config.h
@@ -1,6 +1,5 @@
 #define CONFIG_H
 
-#include "Carbon/Carbon.h"
 #include "cJSON.h"
 #include <pwd.h>
 #include <stdbool.h>
@@ -18,17 +17,10 @@ typedef struct {
 	float distance_pct; // distance
 	float velocity_pct; // velocity
 	float settle_factor;
-
 	float min_step;
 	float min_travel;
 	float min_step_fast;
 	float min_travel_fast;
-
-	CFTimeInterval palm_age;
-	float palm_disp;
-	float palm_velocity;
-	int palm_stationary_threshold;
-
 	const char* swipe_left;
 	const char* swipe_right;
 } Config;
@@ -41,20 +33,13 @@ static Config default_config()
 	config.haptic = false;
 	config.skip_empty = true;
 	config.fingers = 3;
-	config.distance_pct = 0.8f; // ≥12 % travel triggers
-	config.velocity_pct = 0.38f; // ≥0.50 × w pts / s triggers
-	config.settle_factor = 0.25f; // ≤15 % of flick speed -> flick ended
-
-	config.min_step = 0.003f;
-	config.min_travel = 0.010f;
+	config.distance_pct = 0.12f; // ≥12 % travel triggers
+	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
+	config.settle_factor = 0.15f; // ≤15 % of flick speed -> flick ended
+	config.min_step = 0.005f;
+	config.min_travel = 0.015f;
 	config.min_step_fast = 0.0f;
-	config.min_travel_fast = 0.004f;
-
-	config.palm_age = 0.06; // time in seconds before a touch can be a palm
-	config.palm_disp = 0.025f; // max displacement (% of touchpad) for a touch to be a palm
-	config.palm_velocity = 0.1f; // max velocity (trackpad % per second) for a touch to be a palm
-	config.palm_stationary_threshold = 3;
-
+	config.min_travel_fast = 0.006f;
 	config.swipe_left = "prev";
 	config.swipe_right = "next";
 	return config;
@@ -151,38 +136,6 @@ static Config load_config()
 	item = cJSON_GetObjectItem(root, "settle_factor");
 	if (cJSON_IsNumber(item))
 		config.settle_factor = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "min_step");
-	if (cJSON_IsNumber(item))
-		config.min_step = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "min_travel");
-	if (cJSON_IsNumber(item))
-		config.min_travel = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "min_step_fast");
-	if (cJSON_IsNumber(item))
-		config.min_step_fast = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "min_travel_fast");
-	if (cJSON_IsNumber(item))
-		config.min_travel_fast = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "palm_age");
-	if (cJSON_IsNumber(item))
-		config.palm_age = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "palm_disp");
-	if (cJSON_IsNumber(item))
-		config.palm_disp = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "palm_velocity");
-	if (cJSON_IsNumber(item))
-		config.palm_velocity = (float)item->valuedouble;
-
-	item = cJSON_GetObjectItem(root, "palm_stationary_threshold");
-	if (cJSON_IsNumber(item))
-		config.palm_stationary_threshold = item->valueint;
 
 	config.swipe_left = config.natural_swipe ? "next" : "prev";
 	config.swipe_right = config.natural_swipe ? "prev" : "next";

--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,7 @@ typedef struct {
 	CFTimeInterval palm_age;
 	float palm_disp;
 	float palm_velocity;
+	int palm_stationary_threshold;
 
 	const char* swipe_left;
 	const char* swipe_right;
@@ -40,18 +41,19 @@ static Config default_config()
 	config.haptic = false;
 	config.skip_empty = true;
 	config.fingers = 3;
-	config.distance_pct = 0.12f; // ≥12 % travel triggers
-	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
-	config.settle_factor = 0.15f; // ≤15 % of flick speed -> flick ended
+	config.distance_pct = 0.8f; // ≥12 % travel triggers
+	config.velocity_pct = 0.38f; // ≥0.50 × w pts / s triggers
+	config.settle_factor = 0.25f; // ≤15 % of flick speed -> flick ended
 
-	config.min_step = 0.005f;
-	config.min_travel = 0.015f;
+	config.min_step = 0.003f;
+	config.min_travel = 0.010f;
 	config.min_step_fast = 0.0f;
-	config.min_travel_fast = 0.006f;
+	config.min_travel_fast = 0.004f;
 
 	config.palm_age = 0.06; // time in seconds before a touch can be a palm
 	config.palm_disp = 0.025f; // max displacement (% of touchpad) for a touch to be a palm
 	config.palm_velocity = 0.1f; // max velocity (trackpad % per second) for a touch to be a palm
+	config.palm_stationary_threshold = 3;
 
 	config.swipe_left = "prev";
 	config.swipe_right = "next";
@@ -177,6 +179,10 @@ static Config load_config()
 	item = cJSON_GetObjectItem(root, "palm_velocity");
 	if (cJSON_IsNumber(item))
 		config.palm_velocity = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "palm_stationary_threshold");
+	if (cJSON_IsNumber(item))
+		config.palm_stationary_threshold = item->valueint;
 
 	config.swipe_left = config.natural_swipe ? "next" : "prev";
 	config.swipe_right = config.natural_swipe ? "prev" : "next";

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,6 @@
 #define CONFIG_H
 
+#include "Carbon/Carbon.h"
 #include "cJSON.h"
 #include <pwd.h>
 #include <stdbool.h>
@@ -17,10 +18,16 @@ typedef struct {
 	float distance_pct; // distance
 	float velocity_pct; // velocity
 	float settle_factor;
+
 	float min_step;
 	float min_travel;
 	float min_step_fast;
 	float min_travel_fast;
+
+	CFTimeInterval palm_age;
+	float palm_disp;
+	float palm_velocity;
+
 	const char* swipe_left;
 	const char* swipe_right;
 } Config;
@@ -36,10 +43,16 @@ static Config default_config()
 	config.distance_pct = 0.12f; // ≥12 % travel triggers
 	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
 	config.settle_factor = 0.15f; // ≤15 % of flick speed -> flick ended
+
 	config.min_step = 0.005f;
 	config.min_travel = 0.015f;
 	config.min_step_fast = 0.0f;
 	config.min_travel_fast = 0.006f;
+
+	config.palm_age = 0.06; // time in seconds before a touch can be a palm
+	config.palm_disp = 0.025f; // max displacement (% of touchpad) for a touch to be a palm
+	config.palm_velocity = 0.1f; // max velocity (trackpad % per second) for a touch to be a palm
+
 	config.swipe_left = "prev";
 	config.swipe_right = "next";
 	return config;
@@ -136,6 +149,34 @@ static Config load_config()
 	item = cJSON_GetObjectItem(root, "settle_factor");
 	if (cJSON_IsNumber(item))
 		config.settle_factor = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "min_step");
+	if (cJSON_IsNumber(item))
+		config.min_step = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "min_travel");
+	if (cJSON_IsNumber(item))
+		config.min_travel = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "min_step_fast");
+	if (cJSON_IsNumber(item))
+		config.min_step_fast = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "min_travel_fast");
+	if (cJSON_IsNumber(item))
+		config.min_travel_fast = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "palm_age");
+	if (cJSON_IsNumber(item))
+		config.palm_age = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "palm_disp");
+	if (cJSON_IsNumber(item))
+		config.palm_disp = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "palm_velocity");
+	if (cJSON_IsNumber(item))
+		config.palm_velocity = (float)item->valuedouble;
 
 	config.swipe_left = config.natural_swipe ? "next" : "prev";
 	config.swipe_right = config.natural_swipe ? "prev" : "next";

--- a/src/config.h
+++ b/src/config.h
@@ -14,7 +14,6 @@ typedef struct {
 	bool haptic;
 	bool skip_empty;
 	int fingers;
-	float swipe_cooldown;
 	float distance_pct; // distance
 	float velocity_pct; // velocity
 	float settle_factor;
@@ -30,7 +29,6 @@ static Config default_config()
 	config.haptic = false;
 	config.skip_empty = true;
 	config.fingers = 3;
-	config.swipe_cooldown = 0.3f;
 	config.distance_pct = 0.12f; // ≥12 % travel triggers
 	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
 	config.settle_factor = 0.15f; // ≤15 % of flick speed -> flick ended
@@ -118,10 +116,6 @@ static Config load_config()
 	item = cJSON_GetObjectItem(root, "fingers");
 	if (cJSON_IsNumber(item))
 		config.fingers = item->valueint;
-
-	item = cJSON_GetObjectItem(root, "swipe_cooldown");
-	if (cJSON_IsNumber(item))
-		config.swipe_cooldown = (float)item->valuedouble;
 
 	item = cJSON_GetObjectItem(root, "distance_pct");
 	if (cJSON_IsNumber(item))

--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,7 @@ typedef struct {
 	float swipe_cooldown;
 	float distance_pct; // distance
 	float velocity_pct; // velocity
+	float settle_factor;
 	const char* swipe_left;
 	const char* swipe_right;
 } Config;
@@ -32,6 +33,7 @@ static Config default_config()
 	config.swipe_cooldown = 0.3f;
 	config.distance_pct = 0.12f; // ≥12 % travel triggers
 	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
+	config.settle_factor = 0.10f; // ≤10 % of flick speed -> flick ended
 	config.swipe_left = "prev";
 	config.swipe_right = "next";
 	return config;
@@ -128,6 +130,10 @@ static Config load_config()
 	item = cJSON_GetObjectItem(root, "velocity_pct");
 	if (cJSON_IsNumber(item))
 		config.velocity_pct = (float)item->valuedouble;
+
+	item = cJSON_GetObjectItem(root, "settle_factor");
+	if (cJSON_IsNumber(item))
+		config.settle_factor = (float)item->valuedouble;
 
 	config.swipe_left = config.natural_swipe ? "next" : "prev";
 	config.swipe_right = config.natural_swipe ? "prev" : "next";

--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,10 @@ typedef struct {
 	float distance_pct; // distance
 	float velocity_pct; // velocity
 	float settle_factor;
+	float min_step;
+	float min_travel;
+	float min_step_fast;
+	float min_travel_fast;
 	const char* swipe_left;
 	const char* swipe_right;
 } Config;
@@ -32,6 +36,10 @@ static Config default_config()
 	config.distance_pct = 0.12f; // ≥12 % travel triggers
 	config.velocity_pct = 0.50f; // ≥0.50 × w pts / s triggers
 	config.settle_factor = 0.15f; // ≤15 % of flick speed -> flick ended
+	config.min_step = 0.005f;
+	config.min_travel = 0.015f;
+	config.min_step_fast = 0.0f;
+	config.min_travel_fast = 0.006f;
 	config.swipe_left = "prev";
 	config.swipe_right = "next";
 	return config;

--- a/src/event_tap.h
+++ b/src/event_tap.h
@@ -6,13 +6,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define ACTIVATE_PCT 0.05f
+#define END_PHASE 8 // NSTouchPhaseEnded
+#define FAST_VEL_FACTOR 0.80f
+#define MAX_TOUCHES 16
+
 extern const char* get_name_for_pid(uint64_t pid);
 extern char* string_copy(char* s);
-
-#define MAX_TOUCHES 16
-#define ACTIVATE_PCT 0.05f
-#define FAST_VEL_FACTOR 0.80f
-#define END_PHASE 8 // NSTouchPhase
 
 struct event_tap {
 	CFMachPortRef handle;
@@ -26,6 +26,7 @@ typedef struct {
 	int phase;
 	double timestamp;
 	double velocity;
+	bool is_palm;
 } touch;
 
 typedef struct {
@@ -34,49 +35,28 @@ typedef struct {
 	double timestamp;
 } touch_state;
 
-typedef struct {
-	CGPoint start_pos;
-	CGPoint last_pos;
-	CGPoint prev_pos;
-	CFTimeInterval start_time;
-	CFTimeInterval last_time;
-	CFTimeInterval prev_time;
-
-	bool is_palm;
-	bool palm_check_done;
-	float max_velocity;
-	float total_distance;
-	int stationary_frames;
-
-	bool seen;
-	bool valid_for_gesture;
-} finger_track;
-
+// Gesture state enumeration
 typedef enum {
-	GESTURE_STATE_IDLE = 0,
-	GESTURE_STATE_DETECTING,
-	GESTURE_STATE_ARMED,
-	GESTURE_STATE_COMMITTED,
-	GESTURE_STATE_CANCELLED
+	GS_IDLE,
+	GS_ARMED,
+	GS_COMMITTED
 } gesture_state;
 
+// Gesture context structure
 typedef struct {
 	gesture_state state;
-	int last_fire_direction;
+	float start_x, start_y, peak_velx;
+	int dir, last_fire_dir;
+	float prev_x[MAX_TOUCHES], base_x[MAX_TOUCHES];
+} gesture_ctx;
 
-	float start_positions[MAX_TOUCHES];
-	float base_positions[MAX_TOUCHES];
-	float prev_positions[MAX_TOUCHES];
-
-	CGPoint gesture_start;
-	float peak_velocity;
-	int active_finger_count;
-	CFTimeInterval gesture_start_time;
-
-	float velocity_history[3];
-	int velocity_history_idx;
-
-} gesture_context;
+// Palm rejection tracking structure
+typedef struct {
+	CGPoint start, last;
+	CFTimeInterval t_start, t_last;
+	CGFloat travel;
+	bool is_palm, seen;
+} finger_track;
 
 @interface TouchConverter : NSObject
 + (touch)convert_nstouch:(id)nsTouch;

--- a/src/event_tap.h
+++ b/src/event_tap.h
@@ -21,14 +21,35 @@ typedef struct {
 	int phase;
 	double timestamp;
 	double velocity;
-	bool is_palm;
 } touch;
+
+typedef struct {
+	float avg_x;
+	float avg_y;
+	float avg_vel_x;
+	int count;
+} touch_data;
 
 typedef struct {
 	double x;
 	double y;
 	double timestamp;
 } touch_state;
+
+typedef struct {
+	CGPoint start_pos;
+	CGPoint last_pos;
+	CFTimeInterval start_time;
+	CFTimeInterval last_time;
+	bool is_palm;
+	bool seen;
+} finger_track;
+
+typedef enum {
+	GESTURE_STATE_IDLE,
+	GESTURE_STATE_ARMED,
+	GESTURE_STATE_COMMITTED
+} gesture_state;
 
 @interface TouchConverter : NSObject
 + (touch)convert_nstouch:(id)nsTouch;

--- a/src/event_tap.h
+++ b/src/event_tap.h
@@ -9,6 +9,11 @@
 extern const char* get_name_for_pid(uint64_t pid);
 extern char* string_copy(char* s);
 
+#define MAX_TOUCHES 16
+#define ACTIVATE_PCT 0.05f
+#define FAST_VEL_FACTOR 0.80f
+#define END_PHASE 8 // NSTouchPhase
+
 struct event_tap {
 	CFMachPortRef handle;
 	CFRunLoopSourceRef runloop_source;
@@ -24,13 +29,6 @@ typedef struct {
 } touch;
 
 typedef struct {
-	float avg_x;
-	float avg_y;
-	float avg_vel_x;
-	int count;
-} touch_data;
-
-typedef struct {
 	double x;
 	double y;
 	double timestamp;
@@ -39,17 +37,46 @@ typedef struct {
 typedef struct {
 	CGPoint start_pos;
 	CGPoint last_pos;
+	CGPoint prev_pos;
 	CFTimeInterval start_time;
 	CFTimeInterval last_time;
+	CFTimeInterval prev_time;
+
 	bool is_palm;
+	bool palm_check_done;
+	float max_velocity;
+	float total_distance;
+	int stationary_frames;
+
 	bool seen;
+	bool valid_for_gesture;
 } finger_track;
 
 typedef enum {
-	GESTURE_STATE_IDLE,
+	GESTURE_STATE_IDLE = 0,
+	GESTURE_STATE_DETECTING,
 	GESTURE_STATE_ARMED,
-	GESTURE_STATE_COMMITTED
+	GESTURE_STATE_COMMITTED,
+	GESTURE_STATE_CANCELLED
 } gesture_state;
+
+typedef struct {
+	gesture_state state;
+	int last_fire_direction;
+
+	float start_positions[MAX_TOUCHES];
+	float base_positions[MAX_TOUCHES];
+	float prev_positions[MAX_TOUCHES];
+
+	CGPoint gesture_start;
+	float peak_velocity;
+	int active_finger_count;
+	CFTimeInterval gesture_start_time;
+
+	float velocity_history[3];
+	int velocity_history_idx;
+
+} gesture_context;
 
 @interface TouchConverter : NSObject
 + (touch)convert_nstouch:(id)nsTouch;

--- a/src/event_tap.h
+++ b/src/event_tap.h
@@ -21,6 +21,7 @@ typedef struct {
 	int phase;
 	double timestamp;
 	double velocity;
+	bool is_palm;
 } touch;
 
 typedef struct {

--- a/src/main.m
+++ b/src/main.m
@@ -133,6 +133,19 @@ static void gestureCallback(touch* c, int n)
 		}
 	}
 
+	if (n != g_config.fingers) {
+		if (state == GS_ARMED)
+			state = GS_IDLE;
+
+		for (int i = 0; i < n; ++i) {
+			base_x[i] = c[i].x;
+			prev_x[i] = c[i].x;
+		}
+
+		pthread_mutex_unlock(&g_gesture_mutex);
+		return;
+	}
+
 	float sumX = 0, sumY = 0, sumVX = 0;
 	float minX = 1, maxX = 0, minY = 1, maxY = 0;
 	for (int i = 0; i < n; ++i) {

--- a/src/main.m
+++ b/src/main.m
@@ -47,8 +47,6 @@ static void switch_workspace(const char* ws)
 #define END_PHASE 8 // NSTouchPhaseEnded
 #define MIN_STEP 0.005f
 #define MIN_FINGER_TRAVEL 0.015f
-#define MAX_SPREAD_X 0.65f
-#define MAX_SPREAD_Y 0.50f
 #define FAST_VEL_FACTOR 0.80f
 #define MIN_STEP_FAST 0.0f
 #define MIN_TRAVEL_FAST 0.006f
@@ -134,11 +132,6 @@ static void gestureCallback(touch* c, int n)
 	ax /= n;
 	ay /= n;
 	vx /= n;
-
-	//if ((maxX - minX) > MAX_SPREAD_X || (maxY - minY) > MAX_SPREAD_Y) {
-	//	reset();
-	//	goto update;
-	//}
 
 	if (state == GS_IDLE) {
 		bool fast = fabsf(vx) >= g_config.velocity_pct * FAST_VEL_FACTOR;

--- a/src/main.m
+++ b/src/main.m
@@ -47,8 +47,8 @@ static void switch_workspace(const char* ws)
 #define END_PHASE 8 // NSTouchPhaseEnded
 #define MIN_STEP 0.005f
 #define MIN_FINGER_TRAVEL 0.015f
-#define MAX_SPREAD_X 0.65f
-#define MAX_SPREAD_Y 0.50f
+//#define MAX_SPREAD_X 0.65f
+//#define MAX_SPREAD_Y 0.50f
 #define FAST_VEL_FACTOR 0.80f
 #define MIN_STEP_FAST 0.0f
 #define MIN_TRAVEL_FAST 0.006f
@@ -135,10 +135,10 @@ static void gestureCallback(touch* c, int n)
 	ay /= n;
 	vx /= n;
 
-	if ((maxX - minX) > MAX_SPREAD_X || (maxY - minY) > MAX_SPREAD_Y) {
+	/*if ((maxX - minX) > MAX_SPREAD_X || (maxY - minY) > MAX_SPREAD_Y) {
 		reset();
 		goto update;
-	}
+		}*/
 
 	if (state == GS_IDLE) {
 		bool fast = fabsf(vx) >= g_config.velocity_pct * FAST_VEL_FACTOR;

--- a/src/main.m
+++ b/src/main.m
@@ -61,20 +61,13 @@ static void gestureCallback(touch* c, int n)
 	static float peakVelX = 0;
 	static int dir = 0; // +1 R, -1 L
 
-	static double lastSwipeDirTS[2] = { 0, 0 };
-
 	void (^reset)(void) = ^{ state = GS_IDLE; committed = false; };
 
 	void (^fireSwitch)(int) = ^(int d) {
 		if (committed)
 			return;
 
-		double now = CFAbsoluteTimeGetCurrent();
-		if (now - lastSwipeDirTS[DIR_INDEX(d)] < g_config.swipe_cooldown)
-			return;
-
 		committed = true;
-		lastSwipeDirTS[DIR_INDEX(d)] = now;
 
 		const char* ws = (d > 0) ? g_config.swipe_right : g_config.swipe_left;
 		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
@@ -146,7 +139,7 @@ static void gestureCallback(touch* c, int n)
 
 	bool distanceOK = fabsf(dx) >= g_config.distance_pct;
 	bool pressureOff = (endedCnt * 2 >= n) // majority ended
-		|| (fabsf(vx) <= g_config.velocity_pct * g_config.settle_factor); /* slow down */
+		|| (fabsf(vx) <= g_config.velocity_pct * g_config.settle_factor); // slow down
 
 	if (distanceOK && pressureOff)
 		fireSwitch((dx > 0) ? +1 : -1);


### PR DESCRIPTION
removes hidden config values of:
- swipe threshold
- velocity_swipe_threshold
- velocity_frames_threshold

and introduces:
- distance_pct
- velocity_pct

swipes are now more tuned towards feeling like native macos swipes. only one workspace switch is permitted per gesture(regardless of velocity or not). cooldowns now only apply for swipes that are occuring in the same direction to allow quick switch backs(maybe this will be removed, unsure)